### PR TITLE
Add m3exam task

### DIFF
--- a/lm_eval/tasks/m3exam/README.md
+++ b/lm_eval/tasks/m3exam/README.md
@@ -1,0 +1,42 @@
+# Task-name
+
+### Paper
+
+Title: `paper titles goes here`
+
+Abstract: `link to paper PDF or arXiv abstract goes here`
+
+`Short description of paper / benchmark goes here:`
+
+Homepage: `homepage to the benchmark's website goes here, if applicable`
+
+
+### Citation
+
+```
+BibTeX-formatted citation goes here
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `group_name`: `Short description`
+
+#### Tasks
+
+* `task_name`: `1-sentence description of what this particular task does`
+* `task_name2`: ...
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [ ] Is the task an existing benchmark in the literature?
+  * [ ] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/m3exam/README.md
+++ b/lm_eval/tasks/m3exam/README.md
@@ -4,11 +4,11 @@
 
 Title: `M3Exam: A Multilingual, Multimodal, Multilevel Benchmark for Examining Large Language Models`
 
-Abstract: `https://arxiv.org/abs/2210.09261`
+Abstract: https://arxiv.org/abs/2306.05179
 
 We introduce M3Exam, a novel benchmark sourced from real and official human exam questions for evaluating LLMs in a multilingual, multimodal, and multilevel context.
 
-Homepage: `https://github.com/DAMO-NLP-SG/M3Exam`
+Homepage: https://github.com/DAMO-NLP-SG/M3Exam
 
 
 ### Citation
@@ -32,7 +32,7 @@ Homepage: `https://github.com/DAMO-NLP-SG/M3Exam`
 
 #### Tasks
 
-* `m3exam_zeroshot_vi`: `Vietnamese subset with Vietnamese prompt, corresponds to the "Monolingual" strategy from Table 3.`
+* `m3exam_zeroshot_vi`: Vietnamese subset with Vietnamese prompt, corresponds to the "Monolingual" strategy from Table 3.
 
 ### Reproducibility
 
@@ -44,9 +44,9 @@ To reproduce the original implementation's results
 ### Checklist
 
 For adding novel benchmarks/datasets to the library:
-* [ ] Is the task an existing benchmark in the literature?
-  * [ ] Have you referenced the original paper that introduced the task?
-  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
 
 
 If other tasks on this dataset are already supported:

--- a/lm_eval/tasks/m3exam/README.md
+++ b/lm_eval/tasks/m3exam/README.md
@@ -2,31 +2,44 @@
 
 ### Paper
 
-Title: `paper titles goes here`
+Title: `M3Exam: A Multilingual, Multimodal, Multilevel Benchmark for Examining Large Language Models`
 
-Abstract: `link to paper PDF or arXiv abstract goes here`
+Abstract: `https://arxiv.org/abs/2210.09261`
 
-`Short description of paper / benchmark goes here:`
+We introduce M3Exam, a novel benchmark sourced from real and official human exam questions for evaluating LLMs in a multilingual, multimodal, and multilevel context.
 
-Homepage: `homepage to the benchmark's website goes here, if applicable`
+Homepage: `https://github.com/DAMO-NLP-SG/M3Exam`
 
 
 ### Citation
 
 ```
-BibTeX-formatted citation goes here
+@article{zhang2023m3exam,
+      title={M3Exam: A Multilingual, Multimodal, Multilevel Benchmark for Examining Large Language Models},
+      author={Wenxuan Zhang and Sharifah Mahani Aljunied and Chang Gao and Yew Ken Chia and Lidong Bing},
+      year={2023},
+      eprint={2306.05179},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
 ```
 
 ### Groups and Tasks
 
 #### Groups
 
-* `group_name`: `Short description`
+* `m3exam_zeroshot`
 
 #### Tasks
 
-* `task_name`: `1-sentence description of what this particular task does`
-* `task_name2`: ...
+* `m3exam_zeroshot_vi`: `Vietnamese subset with Vietnamese prompt, corresponds to the "Monolingual" strategy from Table 3.`
+
+### Reproducibility
+
+To reproduce the original implementation's results
+
+* Set `batch_size=1`
+* Ensure `max_new_token=3` and `until=[]` in `generation_kwargs`
 
 ### Checklist
 

--- a/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
+++ b/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
@@ -1,5 +1,5 @@
 group:
-  - m3exam
+  - m3exam_zeroshot
 task: m3exam_zeroshot_vi
 dataset_path: chiayewken/m3exam
 dataset_name: vietnamese

--- a/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
+++ b/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
@@ -11,9 +11,16 @@ process_docs: !function m3exam_vi_utils.process_docs
 doc_to_text: "query"
 doc_to_target: "align_target"
 
+filter_list:
+  - name: "multi-choice-extract"
+    filter:
+      - function: !function m3exam_vi_utils.MultiChoiceFilter
+
 metric_list:
   - metric: acc
     aggregation: !function m3exam_vi_utils.mean
+    higher_is_better: true
+
 num_fewshot: 0
 output_type: generate_until
 generation_kwargs:

--- a/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
+++ b/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
@@ -1,0 +1,23 @@
+group:
+  - m3exam
+task: m3exam_zeroshot_vi
+dataset_path: chiayewken/m3exam
+dataset_name: vietnamese
+training_split: null
+validation_split: null
+test_split: test
+
+process_docs: !function m3exam_vi_utils.process_docs
+doc_to_text: "query"
+doc_to_target: "align_target"
+
+metric_list:
+  - metric: acc
+    aggregation: !function m3exam_vi_utils.mean
+num_fewshot: 0
+output_type: generate_until
+generation_kwargs:
+  max_new_tokens: 3
+  until: []
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/m3exam/zeroshot/m3exam_vi_utils.py
+++ b/lm_eval/tasks/m3exam/zeroshot/m3exam_vi_utils.py
@@ -1,0 +1,53 @@
+import datasets
+
+SUBJECT_TO_TARGET = {
+    "language": "Tiếng Việt",
+    "math": "Toán",
+    "social-science": "Khoa học xã hội",
+    "natural-science": "Khoa học tự nhiên",
+}
+ANS_KEYWORD = "Câu trả lời:"
+PROMPT = (
+    "Sau đây là các câu hỏi trắc nghiệm về {subject}. Vui lòng chỉ đưa "
+    "ra phương án đúng, không có bất kỳ chi tiết hay giải thích nào khác.\n\n"
+    "{background}\n{question}\n{options}\nCâu trả lời:"
+)
+
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc):
+        doc["background_description"] = (
+            [] if not doc["background"] else [doc["background"]]
+        )
+        doc["query"] = PROMPT.format(
+            subject=SUBJECT_TO_TARGET[doc["subject_category"]],
+            background="\n".join(doc["background_description"]),
+            question=doc["question_text"],
+            options="\n".join(doc["options"]),
+        )
+        doc["align_target"] = doc["answer_text"]
+        return doc
+
+    return dataset.map(_process_doc)
+
+def mean(items):
+    match = 0
+    total = 0
+    errors = []
+    illformats = []
+
+    for item in items:
+        answer = item[0].strip()
+        # Postprocess based on main.py
+        res = item[1].split(ANS_KEYWORD)[-1].strip().split()[0]
+        pred = res.strip()
+        if len(pred) > 1:
+            if pred[0] != "(":
+                pred = pred[0]   # Assume answer is A) xxxx
+            else:
+                pred = pred[1]   # Assume answer is (A) xxxx
+        if answer == pred:
+            match += 1
+        total += 1
+
+    return match / total


### PR DESCRIPTION
- Add M3Exam Vietnamese zero-shot task
- Verified output match original implementation using the following run config

M3Exam:
```
python main.py \
    --setting zero-shot \
    --method default \
    --model_name opt-125m \
    --selected_langs "['vietnamese']" \
    --selected_levels "['low', 'mid', 'high']" \
    --num_samples all \
    --model_path facebook/opt-125m \
    --output_path ...

python eval.py \
    --selected_langs "['english', 'chinese', 'javanese', 'thai', 'vietnamese']" \
    --setting zero-shot \
    --model_name opt-125m \
    --output_path ...
```
Expected output:
```
Results:
{
    "vietnamese": [
        1789,
        278
    ]
}
0.15539407490218
```

lm-evaluation-harness:
```
lm_eval \
    --model hf \
    --model_args "pretrained=facebook/opt-125m,trust_remote_code=True,dtype=float16" \
    --tasks m3exam_zeroshot_vi \
    --device cuda:0 \
    --batch_size 1 \
    --output_path ... \
    --verbosity DEBUG \
    --log_samples
```
Expected output:
```
hf (pretrained=facebook/opt-125m,trust_remote_code=True,dtype=float16,use_fast_tokenizer=False), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|      Tasks       |Version|       Filter       |n-shot|Metric|Value |   |Stderr|
|------------------|------:|--------------------|-----:|------|-----:|---|------|
|m3exam_zeroshot_vi|      1|multi-choice-extract|     0|acc   |0.1554|±  |N/A   |

{
  "m3exam_zeroshot_vi": {
    "acc,multi-choice-extract": 0.15539407490218,
    "acc_stderr,multi-choice-extract": "N/A",
    "alias": "m3exam_zeroshot_vi"
  }
}
```