### PR TITLE
Add okapi task

### DIFF
--- a/lm_eval/tasks/okapi_mlmm/m_arc/README.md
+++ b/lm_eval/tasks/okapi_mlmm/m_arc/README.md
@@ -1,0 +1,45 @@
+# m\_arc
+
+### Paper
+
+Title: `Okapi: Instruction-tuned Large Language Models in Multiple Languages with Reinforcement Learning from Human Feedback`
+
+Abstract: https://arxiv.org/pdf/2307.16039
+
+Homepage: https://github.com/nlp-uoregon/mlmm-evaluation
+
+
+### Citation
+
+```
+@article{dac2023okapi,
+  title={Okapi: Instruction-tuned Large Language Models in Multiple Languages with Reinforcement Learning from Human Feedback},
+  author={Dac Lai, Viet and Van Nguyen, Chien and Ngo, Nghia Trung and Nguyen, Thuat and Dernoncourt, Franck and Rossi, Ryan A and Nguyen, Thien Huu},
+  journal={arXiv e-prints},
+  pages={arXiv--2307},
+  year={2023}
+}
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `arc_mmlu`: Multi lingual ARC. Supports the Indonesian `id`, Tamil `ta`, Vietnamese `vi`, and Chinese `zh`.
+
+#### Tasks
+
+* `arc_mlmm_{lang}`: ARC task in the specified language
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [ ] Is the task an existing benchmark in the literature?
+  * [ ] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/okapi_mlmm/m_arc/_arc_yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_arc/_arc_yaml
@@ -1,0 +1,31 @@
+group:
+  - arc_mlmm
+dataset_path: aisingapore/m_arc
+dataset_name: null
+dataset_kwargs:
+  revision: dev
+output_type: multiple_choice
+training_split: train
+validation_split: validation
+test_split: test
+
+process_docs: !function utils.process_docs
+doc_to_text: "query"
+doc_to_target: "gold"
+doc_to_choice: "choices"
+
+should_decontaminate: true
+doc_to_decontamination_query: "query"
+
+num_fewshot: 25
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/okapi_mlmm/m_arc/_arc_yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_arc/_arc_yaml
@@ -4,6 +4,7 @@ dataset_path: aisingapore/m_arc
 dataset_name: null
 dataset_kwargs:
   revision: dev
+  trust_remote_code: true
 output_type: multiple_choice
 training_split: train
 validation_split: validation

--- a/lm_eval/tasks/okapi_mlmm/m_arc/arc_id.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_arc/arc_id.yaml
@@ -1,0 +1,3 @@
+include: _arc_yaml
+task: arc_mlmm_id
+dataset_name: arc_id

--- a/lm_eval/tasks/okapi_mlmm/m_arc/arc_ta.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_arc/arc_ta.yaml
@@ -1,0 +1,3 @@
+include: _arc_yaml
+task: arc_mlmm_ta
+dataset_name: arc_ta

--- a/lm_eval/tasks/okapi_mlmm/m_arc/arc_vi.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_arc/arc_vi.yaml
@@ -1,0 +1,3 @@
+include: _arc_yaml
+task: arc_mlmm_vi
+dataset_name: arc_vi

--- a/lm_eval/tasks/okapi_mlmm/m_arc/arc_zh.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_arc/arc_zh.yaml
@@ -1,0 +1,3 @@
+include: _arc_yaml
+task: arc_mlmm_zh
+dataset_name: arc_zh

--- a/lm_eval/tasks/okapi_mlmm/m_arc/utils.py
+++ b/lm_eval/tasks/okapi_mlmm/m_arc/utils.py
@@ -1,0 +1,13 @@
+import datasets
+
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc):
+        out_doc = {
+            "id": doc["id"],
+            "query": f"Question: {doc['question']}\nAnswer:",
+            "choices": doc["choices"],
+            "gold": ["A", "B", "C", "D", "E"].index(doc["answerKey"]),
+        }
+        return out_doc
+    return dataset.map(_process_doc)

--- a/lm_eval/tasks/okapi_mlmm/m_hellaswag/README.md
+++ b/lm_eval/tasks/okapi_mlmm/m_hellaswag/README.md
@@ -1,0 +1,45 @@
+# m\_hellaswag
+
+### Paper
+
+Title: `Okapi: Instruction-tuned Large Language Models in Multiple Languages with Reinforcement Learning from Human Feedback`
+
+Abstract: https://arxiv.org/pdf/2307.16039
+
+Homepage: https://github.com/nlp-uoregon/mlmm-evaluation
+
+
+### Citation
+
+```
+@article{dac2023okapi,
+  title={Okapi: Instruction-tuned Large Language Models in Multiple Languages with Reinforcement Learning from Human Feedback},
+  author={Dac Lai, Viet and Van Nguyen, Chien and Ngo, Nghia Trung and Nguyen, Thuat and Dernoncourt, Franck and Rossi, Ryan A and Nguyen, Thien Huu},
+  journal={arXiv e-prints},
+  pages={arXiv--2307},
+  year={2023}
+}
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `hellaswag_mmlu`: Multi lingual HellaSwag. Supports the Indonesian `id`, Tamil `ta`, Vietnamese `vi`, and Chinese `zh`.
+
+#### Tasks
+
+* `hellaswag_mlmm_{lang}`: HellaSwag task in the specified language
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [ ] Is the task an existing benchmark in the literature?
+  * [ ] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/okapi_mlmm/m_hellaswag/_hellaswag_yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_hellaswag/_hellaswag_yaml
@@ -1,0 +1,31 @@
+group:
+  - hellaswag_mlmm
+dataset_path: aisingapore/m_hellaswag
+dataset_name: null
+dataset_kwargs:
+  revision: dev
+output_type: multiple_choice
+training_split: null
+validation_split: validation
+test_split: null
+
+process_docs: !function utils.process_docs
+doc_to_text: "query"
+doc_to_target: "gold"
+doc_to_choice: "choices"
+
+should_decontaminate: true
+doc_to_decontamination_query: "query"
+
+num_fewshot: 0
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/okapi_mlmm/m_hellaswag/_hellaswag_yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_hellaswag/_hellaswag_yaml
@@ -4,6 +4,7 @@ dataset_path: aisingapore/m_hellaswag
 dataset_name: null
 dataset_kwargs:
   revision: dev
+  trust_remote_code: true
 output_type: multiple_choice
 training_split: null
 validation_split: validation

--- a/lm_eval/tasks/okapi_mlmm/m_hellaswag/hellaswag_id.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_hellaswag/hellaswag_id.yaml
@@ -1,0 +1,3 @@
+include: _hellaswag_yaml
+task: hellaswag_mlmm_id
+dataset_name: hellaswag_id

--- a/lm_eval/tasks/okapi_mlmm/m_hellaswag/hellaswag_ta.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_hellaswag/hellaswag_ta.yaml
@@ -1,0 +1,3 @@
+include: _hellaswag_yaml
+task: hellaswag_mlmm_ta
+dataset_name: hellaswag_ta

--- a/lm_eval/tasks/okapi_mlmm/m_hellaswag/hellaswag_vi.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_hellaswag/hellaswag_vi.yaml
@@ -1,0 +1,3 @@
+include: _hellaswag_yaml
+task: hellaswag_mlmm_vi
+dataset_name: hellaswag_vi

--- a/lm_eval/tasks/okapi_mlmm/m_hellaswag/hellaswag_zh.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_hellaswag/hellaswag_zh.yaml
@@ -1,0 +1,5 @@
+include: _hellaswag_yaml
+task: hellaswag_mlmm_zh
+dataset_name: hellaswag_zh
+
+

--- a/lm_eval/tasks/okapi_mlmm/m_hellaswag/utils.py
+++ b/lm_eval/tasks/okapi_mlmm/m_hellaswag/utils.py
@@ -1,0 +1,24 @@
+import re
+
+import datasets
+
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc):
+        ctx = f"{doc['ctx_a']} {doc['ctx_b'].capitalize()}"
+        out_doc = {
+            "query": preprocess(f"{doc['activity_label']}: {ctx}"),
+            "choices": [preprocess(ending) for ending in doc["endings"]],
+            "gold": int(doc["label"]),
+        }
+        return out_doc
+    return dataset.map(_process_doc)
+
+
+def preprocess(text: str) -> str:
+    text = text.strip()
+    # NOTE: Brackets are artifacts of the WikiHow dataset portion of HellaSwag.
+    text = text.replace(" [title]", ". ")
+    text = re.sub("\\[.*?\\]", "", text)
+    text = text.replace("  ", " ")
+    return text

--- a/lm_eval/tasks/okapi_mlmm/m_mmlu/README.md
+++ b/lm_eval/tasks/okapi_mlmm/m_mmlu/README.md
@@ -1,0 +1,45 @@
+# m\_mmlu
+
+### Paper
+
+Title: `Okapi: Instruction-tuned Large Language Models in Multiple Languages with Reinforcement Learning from Human Feedback`
+
+Abstract: https://arxiv.org/pdf/2307.16039
+
+Homepage: https://github.com/nlp-uoregon/mlmm-evaluation
+
+
+### Citation
+
+```
+@article{dac2023okapi,
+  title={Okapi: Instruction-tuned Large Language Models in Multiple Languages with Reinforcement Learning from Human Feedback},
+  author={Dac Lai, Viet and Van Nguyen, Chien and Ngo, Nghia Trung and Nguyen, Thuat and Dernoncourt, Franck and Rossi, Ryan A and Nguyen, Thien Huu},
+  journal={arXiv e-prints},
+  pages={arXiv--2307},
+  year={2023}
+}
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `mmlu_mmlu`: Multi lingual MMLU. Supports the Indonesian `id`, Tamil `ta`, Vietnamese `vi`, and Chinese `zh`.
+
+#### Tasks
+
+* `mmlu_mlmm_{lang}`: MMLU task in the specified language
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [ ] Is the task an existing benchmark in the literature?
+  * [ ] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/okapi_mlmm/m_mmlu/_mmlu_yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_mmlu/_mmlu_yaml
@@ -4,6 +4,7 @@ dataset_path: aisingapore/m_mmlu
 dataset_name: null
 dataset_kwargs:
   revision: dev
+  trust_remote_code: true
 output_type: multiple_choice
 training_split: null
 validation_split: null

--- a/lm_eval/tasks/okapi_mlmm/m_mmlu/_mmlu_yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_mmlu/_mmlu_yaml
@@ -1,0 +1,34 @@
+group:
+  - mmlu_mlmm
+dataset_path: aisingapore/m_mmlu
+dataset_name: null
+dataset_kwargs:
+  revision: dev
+output_type: multiple_choice
+training_split: null
+validation_split: null
+test_split: test
+fewshot_split: dev
+
+process_docs: !function utils.process_docs
+doc_to_text: "query"
+doc_to_target: "gold"
+doc_to_choice: "choices"
+
+should_decontaminate: true
+doc_to_decontamination_query: "query"
+
+num_fewshot: 25
+fewshot_config:
+  sampler: n_plus_one
+
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/okapi_mlmm/m_mmlu/mmlu_id.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_mmlu/mmlu_id.yaml
@@ -1,0 +1,3 @@
+include: _mmlu_yaml
+task: mmlu_mlmm_id
+dataset_name: mmlu_id

--- a/lm_eval/tasks/okapi_mlmm/m_mmlu/mmlu_ta.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_mmlu/mmlu_ta.yaml
@@ -1,0 +1,3 @@
+include: _mmlu_yaml
+task: mmlu_mlmm_ta
+dataset_name: mmlu_ta

--- a/lm_eval/tasks/okapi_mlmm/m_mmlu/mmlu_vi.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_mmlu/mmlu_vi.yaml
@@ -1,0 +1,3 @@
+include: _mmlu_yaml
+task: mmlu_mlmm_vi
+dataset_name: mmlu_vi

--- a/lm_eval/tasks/okapi_mlmm/m_mmlu/mmlu_zh.yaml
+++ b/lm_eval/tasks/okapi_mlmm/m_mmlu/mmlu_zh.yaml
@@ -1,0 +1,3 @@
+include: _mmlu_yaml
+task: mmlu_mlmm_zh
+dataset_name: mmlu_zh

--- a/lm_eval/tasks/okapi_mlmm/m_mmlu/utils.py
+++ b/lm_eval/tasks/okapi_mlmm/m_mmlu/utils.py
@@ -1,0 +1,25 @@
+import datasets
+
+from lm_eval.api.samplers import ContextSampler
+
+QUERY_PROMPT = "Question: {question}\nChoices:\n{choices}Answer:"
+KEYS = ["A", "B", "C", "D"]
+
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc):
+        out_doc = {
+            "query": QUERY_PROMPT.format(
+                question=doc["question"],
+                choices="".join(
+                    f"{key}. {choice}\n" for key, choice in zip(KEYS, doc["choices"])
+                ),
+            ),
+            "choices": doc["choices"],
+            "gold": (
+                KEYS.index(doc["answer"]) if isinstance(doc["answer"], str) else doc["answer"]
+            ),
+        }
+        return out_doc
+    return dataset.map(_process_doc)
+


### PR DESCRIPTION
Add Okapi tasks:
- arc
- hellaswag
- mmlu

for the following languages:
- id
- ta
- vi
- zh

Implemented a custom sampler to keep `mlmm-evaluation`'s behavior of drawing `num_fewshot + 1` samples for fewshot examples.

Modification to `mlmm-evaluation` [`dev`](https://github.com/aisingapore/mlmm-evaluation/tree/dev) branch
- Change https://github.com/aisingapore/mlmm-evaluation/blob/dev/lm_eval/evaluator.py#L58-L59 to
  ```
  random.seed(0)
  np.random.seed(1234)
  torch.manual_seed(1234)
  ```
  to match the seeds used by [`lm-evaluation-harness`](https://github.com/aisingapore/lm-evaluation-harness/blob/dev/lm_eval/evaluator.py#L77-L81)
- Change https://github.com/aisingapore/mlmm-evaluation/blob/dev/lm_eval/evaluator.py#L187-L189 to
  ```
  rnd = random.Random(1234)
  ```
  to avoid pre-shuffling the dataset and to match the random seed used to initialize the Sampler in lm-evaluation-harness https://github.com/aisingapore/lm-evaluation-harness/blob/add-new-task/lm_eval/api/task.py#L674-L678
- (Optional) Change https://github.com/aisingapore/mlmm-evaluation/blob/dev/lm_eval/evaluator.py#L341 to 
  ```
  for task_name, _, _ in task_dict_items:
  ```
  to enable `--write_out` argument

Modifications to `lm-evaluation-harness`
- Comment out https://github.com/aisingapore/lm-evaluation-harness/blob/dev/lm_eval/utils.py#L837 to avoid shuffling the dataset

# Replicating results

## m_hellaswag

Had to recreate the dataset https://huggingface.co/datasets/aisingapore/m_hellaswag as the `zh` subset does not work on the existing dataset on Hugging Face https://huggingface.co/datasets/alexandrainst/m_hellaswag

### Command
lm-evaluation-harness
```
task_name='hellaswag_mlmm_${lang}'
lm_eval \
    --model hf \
    --model_args "pretrained=facebook/opt-125m,trust_remote_code=True" \
    --tasks "${task_name}" \
    --device cuda:0 \
    --batch_size 1 \
    --output_path "results/${task_name}.json" \
    --verbosity DEBUG \
    --log_samples  
```
mlmm-evaluation
```
task_name="hellaswag_${lang}"
python main.py \
    --model_args "pretrained=facebook/opt-125m,trust_remote_code=True,use_accelerate=True" \
    --tasks "${task_name}" \
    --output_path "results/${task_name}.json" \
    --no_cache
```
### Output
| Task              | Framework             | Metric   | Value               | Stderr |
| ----------------- | --------------------- | -------- | ------------------- | ------ |
| hellaswag_mlmm_id | lm-evaluation-harness | acc      | 0.2680910457375993  | 0.004590128916219268 |
|                   |                       | acc_norm | 0.295361820914752   | 0.004727325016374767 |
| hellaswag_id      | mlmm-evaluation       | acc      | 0.2680910457375993  | 0.004590128916219268 |
|                   |                       | acc_norm | 0.295361820914752   | 0.004727325016374767 |
| hellaswag_mlmm_ta | lm-evaluation-harness | acc      | 0.24533460121240935 | 0.004691448887127335 |
|                   |                       | acc_norm | 0.282182336859622   | 0.0049070711061398155 |
| hellaswag_ta      | mlmm-evaluation       | acc      | 0.24533460121240935 | 0.004691448887127335 |
|                   |                       | acc_norm | 0.282182336859622   | 0.0049070711061398155 |
| hellaswag_mlmm_vi | lm-evaluation-harness | acc      | 0.27406679764243613 | 0.004660205855905225 |
|                   |                       | acc_norm | 0.29971621916612096 | 0.004786529226748529 |
| hellaswag_vi      | mlmm-evaluation       | acc      | 0.27406679764243613 | 0.004660205855905225 |
|                   |                       | acc_norm | 0.29971621916612096 | 0.004786529226748529 |
| hellaswag_mlmm_zh | lm-evaluation-harness | acc      | 0.2691560543924023 | 0.004607779535508573 |
|                   |                       | acc_norm | 0.30110079861860567 | 0.0047658515880019915 |
| hellaswag_zh      | mlmm-evaluation       | acc      | 0.2691560543924023 | 0.004607779535508573 |
|                   |                       | acc_norm | 0.30110079861860567 | 0.0047658515880019915 |


## m_arc

Task on lm-evaluation-harness main branch does not have num_fewshot set

### Command
lm-evaluation-harness
```
task_name='arc_mlmm_${lang}'
lm_eval \
    --model hf \
    --model_args "pretrained=facebook/opt-125m,trust_remote_code=True" \
    --tasks "${task_name}" \
    --device cuda:0 \
    --batch_size 1 \
    --output_path "results/${task_name}.json" \
    --verbosity DEBUG \
    --log_samples  
```
mlmm-evaluation
```
task_name="arc_${lang}"
python main.py \
    --model_args "pretrained=facebook/opt-125m,trust_remote_code=True,use_accelerate=True" \
    --tasks "${task_name}" \
    --output_path "results/${task_name}.json" \
    --no_cache
```
### Output
| Task              | Framework             | Metric   | Value               | Stderr |
| ----------------- | --------------------- | -------- | ------------------- | ------ |
| arc_mlmm_id | lm-evaluation-harness | acc      | 0.18632478632478633  | 0.011388161139389627 |
|             |                       | acc_norm | 0.2341880341880342   | 0.01238614525915231 |
| arc_id      | mlmm-evaluation       | acc      | 0.18632478632478633  | 0.011388161139389627 |
|             |                       | acc_norm | 0.2341880341880342   | 0.01238614525915231 |
| arc_mlmm_ta | lm-evaluation-harness | acc      | 0.2075306479859895 | 0.012005756657930959 |
|             |                       | acc_norm | 0.2530647985989492   | 0.012871065809204451 |
| arc_ta      | mlmm-evaluation       | acc      | 0.2075306479859895 | 0.012005756657930959 |
|             |                       | acc_norm | 0.2530647985989492   | 0.012871065809204451 |
| arc_mlmm_vi | lm-evaluation-harness | acc      | 0.19401709401709402 | 0.011565799456270379 |
|             |                       | acc_norm | 0.22393162393162394 | 0.0121927158461456 |
| arc_vi      | mlmm-evaluation       | acc      | 0.19401709401709402 | 0.011565799456270379 |
|             |                       | acc_norm | 0.22393162393162394 | 0.0121927158461456 |
| arc_mlmm_zh | lm-evaluation-harness | acc      | 0.21367521367521367 | 0.011988664332858041 |
|             |                       | acc_norm | 0.23846153846153847 | 0.01246372437380267 |
| arc_zh      | mlmm-evaluation       | acc      | 0.21367521367521367 | 0.011988664332858041 |
|             |                       | acc_norm | 0.23846153846153847 | 0.01246372437380267 |



## m_mmlu

Task on lm-evaluation-harness main branch uses `first_n` few shot sampling which differ from mlmm-evaluation's implementation

### Command
lm-evaluation-harness
```
task_name='mmlu_mlmm_${lang}'
lm_eval \
    --model hf \
    --model_args "pretrained=facebook/opt-125m,trust_remote_code=True" \
    --tasks "${task_name}" \
    --device cuda:0 \
    --batch_size 1 \
    --output_path "results/${task_name}.json" \
    --verbosity DEBUG \
    --log_samples  
```
mlmm-evaluation
```
task_name="mmlu_${lang}"
python main.py \
    --model_args "pretrained=facebook/opt-125m,trust_remote_code=True,use_accelerate=True" \
    --tasks "${task_name}" \
    --output_path "results/${task_name}.json" \
    --no_cache
```
### Output
| Task              | Framework             | Metric   | Value               | Stderr |
| ----------------- | --------------------- | -------- | ------------------- | ------ |
| mmlu_mlmm_id | lm-evaluation-harness | acc      | 0.24982825738493245  | 0.0037823828185448768 |
|              |                       | acc_norm | 0.27127700175559116   | 0.0038846516351237013 |
| mmlu_id      | mlmm-evaluation       | acc      | 0.24982825738493245  | 0.0037823828185448768 |
|              |                       | acc_norm | 0.27127700175559116   | 0.0038846516351237013 |
| mmlu_mlmm_ta | lm-evaluation-harness | acc      | 0.23364083110612985 | 0.012005756657930959 |
|              |                       | acc_norm | 0.25096991119924134   | 0.004025954925253322 |
| mmlu_ta      | mlmm-evaluation       | acc      | 0.23364083110612985 | 0.003929153519886986 |
|              |                       | acc_norm | 0.25096991119924134   | 0.004025954925253322 |
| mmlu_mlmm_vi | lm-evaluation-harness | acc      | 0.24291838922064002 | 0.003929153519886986 |
|              |                       | acc_norm | 0.265426427805849 | 0.0038636832594341887 |
| mmlu_vi      | mlmm-evaluation       | acc      | 0.24291838922064002 | 0.011565799456270379 |
|              |                       | acc_norm | 0.265426427805849 | 0.0038636832594341887 |
| mmlu_mlmm_zh | lm-evaluation-harness | acc      | 0.23691606532472465 | 0.003705863972342719 |
|              |                       | acc_norm | 0.2614508165590581 | 0.0038299294639917887 |
| mmlu_zh      | mlmm-evaluation       | acc      | 0.23691606532472465 | 0.003705863972342719 |
|              |                       | acc_norm | 0.2614508165590581 | 0.0038299294639917887 |