### PR TITLE
Add indommlu task

### DIFF
--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -7,5 +7,6 @@ from . import gguf
 from . import vllm_causallms
 from . import mamba_lm
 from . import optimum_lm
+from . import indommlu_huggingface
 
 # TODO: implement __all__

--- a/lm_eval/models/indommlu_huggingface.py
+++ b/lm_eval/models/indommlu_huggingface.py
@@ -258,8 +258,6 @@ class INDOMMLU(HFLM):
                         if padding_len_cont is not None
                         else contlen
                     )
-                # print(f"[LOGITS] {inp=}")
-                # print(f"[LOGITS] inp shape: {inp.shape}")
                 padding_len_inp = (
                     max(padding_len_inp, inplen)
                     if padding_len_inp is not None
@@ -267,8 +265,6 @@ class INDOMMLU(HFLM):
                 )
 
                 output_index = inp[1:].reshape(shape=(inplen-1,1))
-                print(f"[LOGITS] {output_index=}")
-                print(f"[LOGITS] output_index shape: {output_index.shape}")
                 output_index_lst.append(output_index)
 
                 inps.append(inp)  # [1, inp_length]
@@ -297,16 +293,10 @@ class INDOMMLU(HFLM):
                     "labels": batched_conts,
                 }
 
-            print(f"[LOGITS] {batched_inps=}")
-            print(f"[LOGITS] batched_inps shape: {batched_inps.shape}")
             outputs = self._model_call(batched_inps, **call_kwargs)
-            print(f"[LOGITS] {outputs=}")
-            print(f"[LOGITS] outputs shape: {outputs.shape}")
             multi_logits = F.log_softmax(
                 self._model_call(batched_inps, **call_kwargs), dim=-1
             )  # [batch, padding_length (inp or cont), vocab]
-            # print(f"[LOGITS] {multi_logits=}")
-            # print(f"[LOGITS] Multi Logits Shape: {multi_logits.shape}")
 
             for (cache_key, _, _), logits, inplen, cont_toks, output_index in zip(
                 chunk, multi_logits, inplens, cont_toks_list, output_index_lst
@@ -334,15 +324,9 @@ class INDOMMLU(HFLM):
 
                 # Obtain log-probs at the corresponding continuation token indices
                 # last_token_slice = logits[:, -1, :].squeeze(0).tolist()
-                # print("[Before Torch Gather....]")
-                # print(f"[LOGITS] Logits Shape: {logits.shape}")
-                # print(f"[LOGITS] output_index Shape: {output_index.shape}")
                 logits = torch.gather(logits, -1, output_index)
-                print(f"[LOGITS] {logits=}")
-                print(f"[LOGITS] Logits Shape: {logits.shape}")
                 # Answer: (log prob, is-exact-match)
                 answer = (float(logits.mean()), bool(max_equal))
-                print(f"[Answer] {answer}")
                 res.append(answer)
 
                 self.cache_hook.add_partial("loglikelihood", cache_key, answer)

--- a/lm_eval/models/indommlu_huggingface.py
+++ b/lm_eval/models/indommlu_huggingface.py
@@ -1,0 +1,353 @@
+from lm_eval.models.huggingface import HFLM
+from lm_eval.api.registry import register_model
+from typing import List, Literal, Optional, Tuple, Union
+import torch
+import torch.nn.functional as F
+import transformers
+from tqdm import tqdm
+from lm_eval import utils
+from lm_eval.utils import Collator
+from lm_eval.api.instance import Instance
+import os
+
+@register_model("indommlu", "IndoMMLU")
+class INDOMMLU(HFLM):
+    """
+    An abstracted Huggingface model class. Enables usage with both models of
+    `transformers.AutoModelForCausalLM` and `transformers.AutoModelForSeq2SeqLM` classes.
+
+    Supports data-parallel multi-GPU with HF Accelerate.
+
+    This class is used to overload the evaluation to mimic the implementation flavor found in 
+    https://github.com/fajri91/IndoMMLU
+    """
+
+    def __init__(
+        self,
+        pretrained: Optional[Union[str, transformers.PreTrainedModel]] = "gpt2",
+        backend: Optional[
+            Literal["default", "causal", "seq2seq"]
+        ] = "default",  # override whether the model should be treated as decoder-only (causal) or encoder-decoder (seq2seq)
+        revision: Optional[str] = "main",
+        subfolder: Optional[str] = None,
+        tokenizer: Optional[
+            Union[
+                str,
+                transformers.PreTrainedTokenizer,
+                transformers.PreTrainedTokenizerFast,
+            ]
+        ] = None,
+        truncation: Optional[bool] = False,
+        max_length: Optional[int] = None,
+        device: Optional[str] = "cuda",
+        dtype: Optional[Union[str, torch.dtype]] = "auto",
+        batch_size: Optional[Union[int, str]] = 1,
+        max_batch_size: Optional[int] = 64,
+        trust_remote_code: Optional[bool] = False,
+        use_fast_tokenizer: Optional[bool] = True,
+        # arguments used for splitting a model across GPUs naively.
+        # only used if `parallelize=True`.
+        parallelize: Optional[bool] = False,
+        device_map_option: Optional[str] = "auto",
+        max_memory_per_gpu: Optional[Union[int, str]] = None,
+        max_cpu_memory: Optional[Union[int, str]] = None,
+        offload_folder: Optional[Union[str, os.PathLike]] = "./offload",
+        # PEFT and quantization options
+        peft: Optional[str] = None,
+        autogptq: Optional[Union[bool, str]] = False,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            pretrained=pretrained,
+            backend=backend,
+            revision=revision,
+            subfolder=subfolder,
+            tokenizer=tokenizer,
+            truncation=truncation,
+            max_length=max_length,
+            device=device,
+            dtype=dtype,
+            batch_size=batch_size,
+            max_batch_size=max_batch_size,
+            trust_remote_code=trust_remote_code,
+            use_fast_tokenizer=use_fast_tokenizer,
+            parallelize=parallelize,
+            device_map_option=device_map_option,
+            max_memory_per_gpu=max_memory_per_gpu,
+            max_cpu_memory=max_cpu_memory,
+            offload_folder=offload_folder,
+            peft=peft,
+            autogptq=autogptq,
+            **kwargs,
+        )
+
+    def _model_call(self, inps, attn_mask=None, labels=None):
+        """
+        :param inps: torch.Tensor
+            A torch tensor of shape [batch, (sequence_ctx + sequence_cont)] or of shape
+            [batch, sequence_ctx]. the size of sequence may vary from call to call
+        :param attn_mask: torch.Tensor, optional
+            A torch tensor of shape [batch, (sequence_ctx + sequence_cont)]. Only passed
+            (and must be passed) if self.AUTO_MODEL_CLASS is transformers.AutoModelForSeq2SeqLM
+        :param labels: torch.Tensor, optional
+            A torch tensor of shape [batch, (sequence_ctx + sequence_cont)]. Only passed
+            (and must be passed) if self.AUTO_MODEL_CLASS is transformers.AutoModelForSeq2SeqLM
+        :return
+            A torch tensor of shape [batch, sequence, vocab] with the
+        logits returned from the model's decoder
+        """
+        with torch.no_grad():
+            if attn_mask is not None or labels is not None:
+                assert attn_mask is not None and labels is not None
+                assert self.AUTO_MODEL_CLASS == transformers.AutoModelForSeq2SeqLM
+                return self.model(
+                    input_ids=inps, attention_mask=attn_mask, labels=labels
+                ).logits
+            else:
+                assert self.AUTO_MODEL_CLASS == transformers.AutoModelForCausalLM
+                outputs = self.model(inps).logits.to(torch.double)
+                return outputs
+
+    def tok_encode(
+        self, string: str, left_truncate_len=None, add_special_tokens=None
+    ) -> List[int]:
+        """ """
+        if add_special_tokens is None:
+            add_special_tokens = True
+
+        encoding = self.tokenizer.encode(string, add_special_tokens=add_special_tokens)
+
+        # left-truncate the encoded context to be at most `left_truncate_len` tokens long
+        if left_truncate_len:
+            encoding = encoding[-left_truncate_len:]
+
+        return encoding
+
+    def _encode_pair(
+        self, context: str, continuation: str
+    ) -> Tuple[List[int], List[int]]:
+        n_spaces = len(context) - len(context.rstrip())
+        if n_spaces > 0:
+            continuation = context[-n_spaces:] + continuation
+            context = context[:-n_spaces]
+
+        whole_enc = self.tok_encode(context + continuation, add_special_tokens=True)
+        context_enc = self.tok_encode(context, add_special_tokens=True)
+        context_enc_len = len(context_enc)
+        continuation_enc = whole_enc[context_enc_len:]
+        return context_enc, continuation_enc
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        new_reqs = []
+        for context, continuation in [req.args for req in requests]:
+            if context == "":
+                # end of text as context
+                context_enc, continuation_enc = (
+                    [self.eot_token_id],
+                    self.tok_encode(continuation),
+                )
+            else:
+                context_enc, continuation_enc = self._encode_pair(context, continuation)
+
+            new_reqs.append(((context, continuation), context_enc, continuation_enc))
+
+        return self._loglikelihood_tokens(new_reqs)
+
+    def _loglikelihood_tokens(
+        self,
+        requests: List[Tuple[Tuple[str, str], List[int], List[int]]],
+        disable_tqdm: bool = False,
+        override_bs: int = None,
+    ) -> List[Tuple[float, bool]]:
+        # TODO: implement some kind of efficient-request-middleware that lumps together requests with the same context
+        res = []
+
+        def _collate(x):
+            """Defines the key for the sorted method"""
+            # the negative sign on len(toks) sorts descending - this has a few advantages:
+            # - time estimates will always be over not underestimates, which is more useful for planning
+            # - to know the size of a batch when going through the list, you know the first one is always the batch
+            #   padded context length. this is useful to simplify the batching logic and more importantly to make
+            #   automatic adaptive batches much much easier to implement
+            # - any OOMs will happen right away rather than near the end
+
+            toks = x[1] + x[2]
+            return -len(toks), tuple(toks)
+
+        re_ord = Collator(requests, sort_fn=_collate)
+
+        # automatic (variable) batch size detection for vectorization
+        # pull longest context sample from request
+        n_reordered_requests = len(re_ord)
+        batch_size = (
+            self.batch_size
+            if self.batch_size != "auto"
+            else override_bs
+            if override_bs is not None
+            else 0
+        )
+        batch_fn = (
+            self._batch_scheduler
+            if self.batch_size == "auto"
+            and n_reordered_requests > 0
+            and not override_bs
+            else None
+        )
+
+        chunks = re_ord.get_batched(n=batch_size, batch_fn=batch_fn)
+        pbar = tqdm(total=len(requests), disable=(disable_tqdm or (self.rank != 0)))
+        for chunk in chunks:
+            inps = []
+            cont_toks_list = []
+            inplens = []
+            output_index_lst = []
+
+            conts = []
+            encoder_attns = []
+
+            padding_len_inp = None
+            padding_len_cont = None
+            # because vectorizing is annoying, we first convert each (context, continuation) pair to padded
+            # tensors, then we pack them together into a batch, call the model, and then pick it all apart
+            # again because vectorizing is annoying
+
+            for _, context_enc, continuation_enc in chunk:
+                # sanity check
+                assert len(context_enc) > 0
+                assert len(continuation_enc) > 0
+                assert len(continuation_enc) <= self.max_length
+                # how this all works (illustrated on a causal decoder-only setup):
+                #          CTX      CONT
+                # inp    0 1 2 3|4 5 6 7 8 9   <- last token is deleted by inp[:, :-1]
+                # model  \               \
+                # logits   1 2 3|4 5 6 7 8 9   <- the ctx half gets tossed out by the
+                # cont_toks      4 5 6 7 8 9      [:, -len(continuation_enc):, :self.vocab_size] slice
+
+                # when too long to fit in context, truncate from the left
+                if self.AUTO_MODEL_CLASS == transformers.AutoModelForCausalLM:
+                    inp = torch.tensor(
+                        (context_enc + continuation_enc)[-(self.max_length + 1) :],
+                        dtype=torch.long,
+                        device=self.device,
+                    )
+                    (inplen,) = inp.shape
+                elif self.AUTO_MODEL_CLASS == transformers.AutoModelForSeq2SeqLM:
+                    inp = torch.tensor(
+                        (context_enc)[-self.max_length :],
+                        dtype=torch.long,
+                        device=self.device,
+                    )
+                    (inplen,) = inp.shape
+
+                    # build encoder attn masks
+                    encoder_attns.append(torch.ones_like(inp))
+
+                    cont = torch.tensor(
+                        (continuation_enc)[-self.max_length :],
+                        # TODO: left-shift these?
+                        # TODO: our code assumes we never end up truncating conts for either model type
+                        dtype=torch.long,
+                        device=self.device,
+                    )
+                    (contlen,) = cont.shape
+
+                    conts.append(cont)
+
+                    padding_len_cont = (
+                        max(padding_len_cont, contlen)
+                        if padding_len_cont is not None
+                        else contlen
+                    )
+                # print(f"[LOGITS] {inp=}")
+                # print(f"[LOGITS] inp shape: {inp.shape}")
+                padding_len_inp = (
+                    max(padding_len_inp, inplen)
+                    if padding_len_inp is not None
+                    else inplen
+                )
+
+                output_index = inp[1:].reshape(shape=(inplen-1,1))
+                print(f"[LOGITS] {output_index=}")
+                print(f"[LOGITS] output_index shape: {output_index.shape}")
+                output_index_lst.append(output_index)
+
+                inps.append(inp)  # [1, inp_length]
+                cont_toks_list.append(continuation_enc)
+                inplens.append(inplen)
+
+            # create encoder attn mask and batched conts, if seq2seq
+            call_kwargs = {}
+            if self.AUTO_MODEL_CLASS == transformers.AutoModelForCausalLM:
+                batched_inps = utils.pad_and_concat(
+                    padding_len_inp, inps, padding_side="right"
+                )  # [batch, padding_len_inp]
+            elif self.AUTO_MODEL_CLASS == transformers.AutoModelForSeq2SeqLM:
+                # TODO: left-pad encoder inps and mask?
+                batched_inps = utils.pad_and_concat(
+                    padding_len_inp, inps
+                )  # [batch, padding_len_inp]
+                batched_conts = utils.pad_and_concat(
+                    padding_len_cont, conts
+                )  # [batch, padding_len_cont]
+                batched_encoder_mask = utils.pad_and_concat(
+                    padding_len_inp, encoder_attns
+                )  # [batch, padding_len_inp]
+                call_kwargs = {
+                    "attn_mask": batched_encoder_mask,
+                    "labels": batched_conts,
+                }
+
+            print(f"[LOGITS] {batched_inps=}")
+            print(f"[LOGITS] batched_inps shape: {batched_inps.shape}")
+            outputs = self._model_call(batched_inps, **call_kwargs)
+            print(f"[LOGITS] {outputs=}")
+            print(f"[LOGITS] outputs shape: {outputs.shape}")
+            multi_logits = F.log_softmax(
+                self._model_call(batched_inps, **call_kwargs), dim=-1
+            )  # [batch, padding_length (inp or cont), vocab]
+            # print(f"[LOGITS] {multi_logits=}")
+            # print(f"[LOGITS] Multi Logits Shape: {multi_logits.shape}")
+
+            for (cache_key, _, _), logits, inplen, cont_toks, output_index in zip(
+                chunk, multi_logits, inplens, cont_toks_list, output_index_lst
+            ):
+                # Slice to original seq length
+                contlen = len(cont_toks)
+                # take only logits in the continuation
+                # (discard context toks if decoder-only ; discard right-padding)
+                # also discards + checks for "virtual tokens" in the causal LM's input window
+                # from prompt/prefix tuning tokens, if applicable
+                ctx_len = (
+                    inplen + (logits.shape[0] - padding_len_inp)
+                    if self.AUTO_MODEL_CLASS == transformers.AutoModelForCausalLM
+                    else None
+                )
+                cont_logits = self._select_cont_toks(logits, contlen=contlen, inplen=ctx_len)
+                cont_logits = cont_logits.unsqueeze(0)  # [1, seq, vocab]
+
+                # Check if per-token argmax is exactly equal to continuation
+                greedy_tokens = cont_logits.argmax(dim=-1)
+                cont_toks = torch.tensor(
+                    cont_toks, dtype=torch.long, device=self.device
+                ).unsqueeze(0)  # [1, seq]
+                max_equal = (greedy_tokens == cont_toks).all()
+
+                # Obtain log-probs at the corresponding continuation token indices
+                # last_token_slice = logits[:, -1, :].squeeze(0).tolist()
+                # print("[Before Torch Gather....]")
+                # print(f"[LOGITS] Logits Shape: {logits.shape}")
+                # print(f"[LOGITS] output_index Shape: {output_index.shape}")
+                logits = torch.gather(logits, -1, output_index)
+                print(f"[LOGITS] {logits=}")
+                print(f"[LOGITS] Logits Shape: {logits.shape}")
+                # Answer: (log prob, is-exact-match)
+                answer = (float(logits.mean()), bool(max_equal))
+                print(f"[Answer] {answer}")
+                res.append(answer)
+
+                self.cache_hook.add_partial("loglikelihood", cache_key, answer)
+                pbar.update(1)
+
+        pbar.close()
+
+        return re_ord.get_original(res)

--- a/lm_eval/models/indommlu_huggingface.py
+++ b/lm_eval/models/indommlu_huggingface.py
@@ -1,14 +1,17 @@
-from lm_eval.models.huggingface import HFLM
-from lm_eval.api.registry import register_model
+import os
 from typing import List, Literal, Optional, Tuple, Union
+
 import torch
 import torch.nn.functional as F
 import transformers
 from tqdm import tqdm
+
 from lm_eval import utils
-from lm_eval.utils import Collator
 from lm_eval.api.instance import Instance
-import os
+from lm_eval.api.registry import register_model
+from lm_eval.models.huggingface import HFLM
+from lm_eval.utils import Collator
+
 
 @register_model("indommlu", "IndoMMLU")
 class INDOMMLU(HFLM):

--- a/lm_eval/tasks/indo_mmlu/indommlu.yaml
+++ b/lm_eval/tasks/indo_mmlu/indommlu.yaml
@@ -1,0 +1,22 @@
+task: indo_mmlu
+dataset_path: aisingapore/IndoMMLU
+dataset_name: null
+output_type: multiple_choice
+training_split: null
+validation_split: null
+test_split: test
+num_fewshot: 0
+process_docs: !function preprocess_indommlu._process_doc
+process_results: !function preprocess_indommlu._process_results
+doc_to_text: prompt
+doc_to_target: doc_to_target
+doc_to_choice: doc_to_choice
+metric_list:
+  - metric: acc
+    aggregation: mean
+    higher_is_better: true
+  - metric: acc_norm
+    aggregation: mean
+    higher_is_better: true
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/indo_mmlu/preprocess_indommlu.py
+++ b/lm_eval/tasks/indo_mmlu/preprocess_indommlu.py
@@ -1,0 +1,81 @@
+import datasets
+
+def indommlu_doc_to_target(doc):
+    processed_options = list(map(lambda x: x[0], doc["options"]))
+    return processed_options.index(doc["answer"])
+
+def indommlu_doc_to_choice(doc):
+    return list(map(lambda x: x.split(' ', 1)[1], eval(doc["options"])))
+
+def _process_doc(dataset: datasets.Dataset):
+    def _helper(doc):
+        options = eval(doc["options"])
+        options_string = '\n'.join(options)
+        idx = ord(doc["answer"]) - ord("A")
+        if idx >= len(options):
+            idx = len(options) - 1
+            doc["to_compile"] = 0
+        else:
+            doc["to_compile"] = 1
+        doc["prompt"] = f"Ini adalah soal {doc['subject']} untuk {doc['level']}. Pilihlah salah satu jawaban yang dianggap benar!\n\n{doc['question']}\n{options_string}\n\nJawaban:"
+        doc["doc_to_target"] = idx
+        doc["doc_to_choice"] = options
+        return doc
+    return dataset.map(_helper)
+
+def _process_results(doc, results):
+    result_dict = {}
+    lls, is_greedy = zip(*results)
+
+    # retrieve choices in List[str] form, to compute choice lengths, etc.
+    choices = doc["doc_to_choice"]
+    completion_len = np.array([float(len(i)) for i in choices])
+
+    pred = np.argmax(lls)
+    pred_norm = np.argmax(lls / completion_len)
+
+    if self.multiple_input:
+        gold = doc["doc_to_text"]
+    else:
+        gold = doc["doc_to_target"]
+
+    gold_index_error = False
+    if isinstance(gold, list):
+        gold = [i if i < len(choices) else -100 for i in gold]
+        if -100 in gold:
+            gold_index_error = True
+    else:
+        if isinstance(gold, int):
+            gold = gold if gold < len(choices) else -100
+        elif isinstance(gold, str):
+            gold = choices.index(gold) if gold in choices else -100
+
+        if gold == -100:
+            gold_index_error = True
+
+    if gold_index_error:
+        eval_logger.warning(
+            f"Label index was not in within range of available choices,"
+            f"Sample:\n\n{doc}\n\n"
+        )
+
+    if self.multiple_target:
+        acc = 1.0 if pred in gold else 0.0
+        acc_norm = 1.0 if pred_norm in gold else 0.0
+        exact_match = int(any([is_greedy[i] if i != -100 else 0 for i in gold]))
+    else:
+        acc = 1.0 if pred == gold else 0.0
+        acc_norm = 1.0 if pred_norm == gold else 0.0
+        # TODO: this gets score of 0 on arc_challenge for pythia-70m. need to test that this works properly
+        exact_match = int(is_greedy[gold]) if gold != -100 else 0
+
+    acc *= doc["to_compile"]
+    acc_norm *= doc["to_compile"]
+    exact_match *= doc["to_compile"]
+
+    result_dict = {
+        **({"acc": acc}),
+        **({"acc_norm": acc_norm})
+    }
+
+    return result_dict

--- a/lm_eval/tasks/indo_mmlu/preprocess_indommlu.py
+++ b/lm_eval/tasks/indo_mmlu/preprocess_indommlu.py
@@ -1,4 +1,5 @@
 import datasets
+import numpy as np
 
 def indommlu_doc_to_target(doc):
     processed_options = list(map(lambda x: x[0], doc["options"]))
@@ -34,11 +35,7 @@ def _process_results(doc, results):
     pred = np.argmax(lls)
     pred_norm = np.argmax(lls / completion_len)
 
-    if self.multiple_input:
-        gold = doc["doc_to_text"]
-    else:
-        gold = doc["doc_to_target"]
-
+    gold = doc["doc_to_target"]
     gold_index_error = False
     if isinstance(gold, list):
         gold = [i if i < len(choices) else -100 for i in gold]
@@ -59,15 +56,10 @@ def _process_results(doc, results):
             f"Sample:\n\n{doc}\n\n"
         )
 
-    if self.multiple_target:
-        acc = 1.0 if pred in gold else 0.0
-        acc_norm = 1.0 if pred_norm in gold else 0.0
-        exact_match = int(any([is_greedy[i] if i != -100 else 0 for i in gold]))
-    else:
-        acc = 1.0 if pred == gold else 0.0
-        acc_norm = 1.0 if pred_norm == gold else 0.0
-        # TODO: this gets score of 0 on arc_challenge for pythia-70m. need to test that this works properly
-        exact_match = int(is_greedy[gold]) if gold != -100 else 0
+    acc = 1.0 if pred == gold else 0.0
+    acc_norm = 1.0 if pred_norm == gold else 0.0
+    # TODO: this gets score of 0 on arc_challenge for pythia-70m. need to test that this works properly
+    exact_match = int(is_greedy[gold]) if gold != -100 else 0
 
     acc *= doc["to_compile"]
     acc_norm *= doc["to_compile"]

--- a/lm_eval/tasks/m3exam/README.md
+++ b/lm_eval/tasks/m3exam/README.md
@@ -1,0 +1,42 @@
+# Task-name
+
+### Paper
+
+Title: `paper titles goes here`
+
+Abstract: `link to paper PDF or arXiv abstract goes here`
+
+`Short description of paper / benchmark goes here:`
+
+Homepage: `homepage to the benchmark's website goes here, if applicable`
+
+
+### Citation
+
+```
+BibTeX-formatted citation goes here
+```
+
+### Groups and Tasks
+
+#### Groups
+
+* `group_name`: `Short description`
+
+#### Tasks
+
+* `task_name`: `1-sentence description of what this particular task does`
+* `task_name2`: ...
+
+### Checklist
+
+For adding novel benchmarks/datasets to the library:
+* [ ] Is the task an existing benchmark in the literature?
+  * [ ] Have you referenced the original paper that introduced the task?
+  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+
+
+If other tasks on this dataset are already supported:
+* [ ] Is the "Main" variant of this task clearly denoted?
+* [ ] Have you provided a short sentence in a README on what each new variant adds / evaluates?
+* [ ] Have you noted which, if any, published evaluation setups are matched by this variant?

--- a/lm_eval/tasks/m3exam/README.md
+++ b/lm_eval/tasks/m3exam/README.md
@@ -4,11 +4,11 @@
 
 Title: `M3Exam: A Multilingual, Multimodal, Multilevel Benchmark for Examining Large Language Models`
 
-Abstract: `https://arxiv.org/abs/2210.09261`
+Abstract: https://arxiv.org/abs/2306.05179
 
 We introduce M3Exam, a novel benchmark sourced from real and official human exam questions for evaluating LLMs in a multilingual, multimodal, and multilevel context.
 
-Homepage: `https://github.com/DAMO-NLP-SG/M3Exam`
+Homepage: https://github.com/DAMO-NLP-SG/M3Exam
 
 
 ### Citation
@@ -32,7 +32,7 @@ Homepage: `https://github.com/DAMO-NLP-SG/M3Exam`
 
 #### Tasks
 
-* `m3exam_zeroshot_vi`: `Vietnamese subset with Vietnamese prompt, corresponds to the "Monolingual" strategy from Table 3.`
+* `m3exam_zeroshot_vi`: Vietnamese subset with Vietnamese prompt, corresponds to the "Monolingual" strategy from Table 3.
 
 ### Reproducibility
 
@@ -44,9 +44,9 @@ To reproduce the original implementation's results
 ### Checklist
 
 For adding novel benchmarks/datasets to the library:
-* [ ] Is the task an existing benchmark in the literature?
-  * [ ] Have you referenced the original paper that introduced the task?
-  * [ ] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
+* [x] Is the task an existing benchmark in the literature?
+  * [x] Have you referenced the original paper that introduced the task?
+  * [x] If yes, does the original paper provide a reference implementation? If so, have you checked against the reference implementation and documented how to run such a test?
 
 
 If other tasks on this dataset are already supported:

--- a/lm_eval/tasks/m3exam/README.md
+++ b/lm_eval/tasks/m3exam/README.md
@@ -2,31 +2,44 @@
 
 ### Paper
 
-Title: `paper titles goes here`
+Title: `M3Exam: A Multilingual, Multimodal, Multilevel Benchmark for Examining Large Language Models`
 
-Abstract: `link to paper PDF or arXiv abstract goes here`
+Abstract: `https://arxiv.org/abs/2210.09261`
 
-`Short description of paper / benchmark goes here:`
+We introduce M3Exam, a novel benchmark sourced from real and official human exam questions for evaluating LLMs in a multilingual, multimodal, and multilevel context.
 
-Homepage: `homepage to the benchmark's website goes here, if applicable`
+Homepage: `https://github.com/DAMO-NLP-SG/M3Exam`
 
 
 ### Citation
 
 ```
-BibTeX-formatted citation goes here
+@article{zhang2023m3exam,
+      title={M3Exam: A Multilingual, Multimodal, Multilevel Benchmark for Examining Large Language Models},
+      author={Wenxuan Zhang and Sharifah Mahani Aljunied and Chang Gao and Yew Ken Chia and Lidong Bing},
+      year={2023},
+      eprint={2306.05179},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
 ```
 
 ### Groups and Tasks
 
 #### Groups
 
-* `group_name`: `Short description`
+* `m3exam_zeroshot`
 
 #### Tasks
 
-* `task_name`: `1-sentence description of what this particular task does`
-* `task_name2`: ...
+* `m3exam_zeroshot_vi`: `Vietnamese subset with Vietnamese prompt, corresponds to the "Monolingual" strategy from Table 3.`
+
+### Reproducibility
+
+To reproduce the original implementation's results
+
+* Set `batch_size=1`
+* Ensure `max_new_token=3` and `until=[]` in `generation_kwargs`
 
 ### Checklist
 

--- a/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
+++ b/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
@@ -1,5 +1,5 @@
 group:
-  - m3exam
+  - m3exam_zeroshot
 task: m3exam_zeroshot_vi
 dataset_path: chiayewken/m3exam
 dataset_name: vietnamese

--- a/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
+++ b/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
@@ -11,9 +11,16 @@ process_docs: !function m3exam_vi_utils.process_docs
 doc_to_text: "query"
 doc_to_target: "align_target"
 
+filter_list:
+  - name: "multi-choice-extract"
+    filter:
+      - function: !function m3exam_vi_utils.MultiChoiceFilter
+
 metric_list:
   - metric: acc
     aggregation: !function m3exam_vi_utils.mean
+    higher_is_better: true
+
 num_fewshot: 0
 output_type: generate_until
 generation_kwargs:

--- a/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
+++ b/lm_eval/tasks/m3exam/zeroshot/m3exam_vi.yaml
@@ -1,0 +1,23 @@
+group:
+  - m3exam
+task: m3exam_zeroshot_vi
+dataset_path: chiayewken/m3exam
+dataset_name: vietnamese
+training_split: null
+validation_split: null
+test_split: test
+
+process_docs: !function m3exam_vi_utils.process_docs
+doc_to_text: "query"
+doc_to_target: "align_target"
+
+metric_list:
+  - metric: acc
+    aggregation: !function m3exam_vi_utils.mean
+num_fewshot: 0
+output_type: generate_until
+generation_kwargs:
+  max_new_tokens: 3
+  until: []
+metadata:
+  version: 1.0

--- a/lm_eval/tasks/m3exam/zeroshot/m3exam_vi_utils.py
+++ b/lm_eval/tasks/m3exam/zeroshot/m3exam_vi_utils.py
@@ -1,0 +1,53 @@
+import datasets
+
+SUBJECT_TO_TARGET = {
+    "language": "Tiếng Việt",
+    "math": "Toán",
+    "social-science": "Khoa học xã hội",
+    "natural-science": "Khoa học tự nhiên",
+}
+ANS_KEYWORD = "Câu trả lời:"
+PROMPT = (
+    "Sau đây là các câu hỏi trắc nghiệm về {subject}. Vui lòng chỉ đưa "
+    "ra phương án đúng, không có bất kỳ chi tiết hay giải thích nào khác.\n\n"
+    "{background}\n{question}\n{options}\nCâu trả lời:"
+)
+
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    def _process_doc(doc):
+        doc["background_description"] = (
+            [] if not doc["background"] else [doc["background"]]
+        )
+        doc["query"] = PROMPT.format(
+            subject=SUBJECT_TO_TARGET[doc["subject_category"]],
+            background="\n".join(doc["background_description"]),
+            question=doc["question_text"],
+            options="\n".join(doc["options"]),
+        )
+        doc["align_target"] = doc["answer_text"]
+        return doc
+
+    return dataset.map(_process_doc)
+
+def mean(items):
+    match = 0
+    total = 0
+    errors = []
+    illformats = []
+
+    for item in items:
+        answer = item[0].strip()
+        # Postprocess based on main.py
+        res = item[1].split(ANS_KEYWORD)[-1].strip().split()[0]
+        pred = res.strip()
+        if len(pred) > 1:
+            if pred[0] != "(":
+                pred = pred[0]   # Assume answer is A) xxxx
+            else:
+                pred = pred[1]   # Assume answer is (A) xxxx
+        if answer == pred:
+            match += 1
+        total += 1
+
+    return match / total


### PR DESCRIPTION
**Add indommlu task**

* Added a new HFLM class to redefine the loglikelihood token
* Task include a preprocessing script
    * Convert dataset similar to the fajri91 implementation
    * Change the target if the answer is not within the choices (harness insists that answer has to be within the choices), but we include a parameter to convert the metric score if the condition above exists
* Task include a postprocessing script
    * To score the model's output based on fajri91 repo
    * Convert the metrics score to 0 if the original answer is not within the choices

** Batch size has to be 1 to be able to replicate the results from fajri91 repo **
** To call the new HFLM class, you need to include --model indommlu **

** Replicating Results **
To use the fajri91 repo:
```
cd <path>/<to>/<IndoMMLU>

python evaluate.py \
    --base_model="facebook/opt-125m" \
    --output_folder="<path>/<output>/<folder>"
```
To use the harness repo:
```
cd <path>/<to>/<lm-evaluation-harness>

accelerate launch -m lm_eval \
    --model indommlu \
    --model_args="pretrained=facebook/opt-125m,trust_remote_code=True,dtype=float16" \
    --tasks="indo_mmlu" \
    --batch_size 1 \
    --output_path="$(pwd)/output_test.json" \
    --verbosity DEBUG \
    --log_samples
```

 
